### PR TITLE
Potential fix for code scanning alert no. 89: Use of insecure SSL/TLS version

### DIFF
--- a/homeassistant/components/tcp/entity.py
+++ b/homeassistant/components/tcp/entity.py
@@ -52,6 +52,7 @@ class TcpEntity(Entity):
         self._ssl_context: ssl.SSLContext | None = None
         if self._config[CONF_SSL]:
             self._ssl_context = ssl.create_default_context()
+            self._ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
             if not self._config[CONF_VERIFY_SSL]:
                 self._ssl_context.check_hostname = False
                 self._ssl_context.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
Potential fix for [https://github.com/parkerbxyz/home-assistant-core/security/code-scanning/89](https://github.com/parkerbxyz/home-assistant-core/security/code-scanning/89)

To fix this safely, keep using `ssl.create_default_context()` (good defaults/cert handling) but explicitly require TLS 1.2+ on the created context.  
Best fix in this file is to set `self._ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2` immediately after creating the context in `__init__`.

This change should be made in `homeassistant/components/tcp/entity.py` in the `if self._config[CONF_SSL]:` block (around lines 53–58), right after line 54. No new imports are needed since `ssl` is already imported. This preserves existing functionality (including optional cert verification disabling) while preventing TLS 1.0/1.1 negotiation and addressing both alert variants.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
